### PR TITLE
Find function

### DIFF
--- a/lib/Parse.js
+++ b/lib/Parse.js
@@ -25,9 +25,9 @@ Parse.prototype = {
   // get an object from the class store
   find: function (className, query, callback) {
     if (typeof query === 'string') {
-      parseRequest.call(this, 'GET', '/1/' + className + '/' + query, null, callback);
+      parseRequest.call(this, 'GET', '/1/classes/' + className + '/' + query, null, callback);
     } else {
-      parseRequest.call(this, 'GET', '/1/' + className, { where: JSON.stringify(query) }, callback);
+      parseRequest.call(this, 'GET', '/1/classes/' + className, { where: JSON.stringify(query) }, callback);
     }
   },
 


### PR DESCRIPTION
I've noticed the find: function only works with /classes/ at the end in the Parse.com REST API, please have a look and run the test, it seems to be working now...
