### PR TITLE
Use utf8-safe method to calculate body length

### DIFF
--- a/lib/Parse.js
+++ b/lib/Parse.js
@@ -215,10 +215,10 @@ function parseRequest(method, path, data, callback, contentType) {
       break;
     case 'POST':
       body = typeof data === 'object' ? JSON.stringify(data) : data;
-      headers['Content-length'] = body.length;
+      headers['Content-length'] = Buffer.byteLength(body);
     case 'PUT':
       body = typeof data === 'object' ? JSON.stringify(data) : data;
-      headers['Content-length'] = body.length;
+      headers['Content-length'] = Buffer.byteLength(body);
       headers['Content-type'] = contentType || 'application/json';
       break;
     case 'DELETE':


### PR DESCRIPTION
Parse thrown HTTP 400 when we send utf8 content. Thus, use Buffer.byteLength(body) to correctly calculate body.length
