### PR TITLE
Problems with querystring.escape and findMany

### DIFF
--- a/lib/Parse.js
+++ b/lib/Parse.js
@@ -1,5 +1,7 @@
 var qs = require('querystring');
 
+qs.escape = function(q){ return q; };
+
 module.exports = Parse;
 
 function Parse(application_id, master_key) {
@@ -45,7 +47,9 @@ Parse.prototype = {
     if (typeof(query) === 'string') {
       parseRequest.call(this, 'GET', '/1/classes/' + className + '/' + query, null, callback);
     } else {
-      parseRequest.call(this, 'GET', '/1/classes/' + className, {limit: limit, order:order, where: JSON.stringify(query) }, callback);
+      data = {order: order, where: JSON.stringify(query)};
+      if (limit) data.limit = limit;
+      parseRequest.call(this, 'GET', '/1/classes/' + className, data, callback);
     }
   },
   


### PR DESCRIPTION
The query string was escaped, never creating a GET request properly formatted.
Also, if I called findMany without the argument limit, the request would be wrong too, since this cannot be empty and MUST be an integer.
