### PR TITLE
Removed duplication of findMany function

### DIFF
--- a/lib/Parse.js
+++ b/lib/Parse.js
@@ -34,22 +34,20 @@ Parse.prototype = {
   },
 
   // get a collection of objects
-  findMany: function (className, query, callback) {
-    if (typeof(query) === 'string') {
-      parseRequest.call(this, 'GET', '/1/classes/' + className + '/' + query, null, callback);
-    } else {
-      parseRequest.call(this, 'GET', '/1/classes/' + className, { where: JSON.stringify(query) }, callback);
+  findMany: function (className, query, order, limit, callback) {
+    // also supports the following api - findMany: function (className, query, callback)
+
+    // if only 3 arguments exist, third argument is the callback, order and limit are undefined
+    if (arguments.length === 3) {
+      var callback = order;
+      var order = undefined;
+      var limit = undefined;
     }
-  },
- 
-  // get a collection of objects
-  findMany: function (className, query,order,limit, callback) {
+
     if (typeof(query) === 'string') {
       parseRequest.call(this, 'GET', '/1/classes/' + className + '/' + query, null, callback);
     } else {
-      data = {order: order, where: JSON.stringify(query)};
-      if (limit) data.limit = limit;
-      parseRequest.call(this, 'GET', '/1/classes/' + className, data, callback);
+      parseRequest.call(this, 'GET', '/1/classes/' + className, {limit: limit, order:order, where: JSON.stringify(query) }, callback);
     }
   },
   


### PR DESCRIPTION
There are currently two `findMany` functions: one that supports the `function (className, query, callback)` API, and one that supports the `function (className, query, order, limit, callback)` API. This pull request combines these duplicated `findMany` functions into a single function that supports both API formats.
