### PR TITLE
Clarified how to use `findMany` to return all items in a class

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -60,6 +60,12 @@ examples
       console.log(response);
     });
 
+
+    // all Foo objects
+    app.findMany('Foo', '', function (err, response) {
+      console.log(response);
+    }):
+
 ### count the number of objects
 
    //just use findMany, and call results.length on the response


### PR DESCRIPTION
It's currently necessary to read the source code in order to determine how to return all items in a class. This adds this usage to the documentation.
