### PR TITLE
Support for "include"

### DIFF
--- a/lib/Parse.js
+++ b/lib/Parse.js
@@ -220,7 +220,7 @@ function parseRequest(method, path, data, callback, contentType) {
   switch (method) {
     case 'GET':
       if (data) {
-        path += '?' + qs.stringify(data);
+        path += (path.indexOf("?") == -1 ? '?' : '&') + qs.stringify(data);
       }
       break;
     case 'POST':


### PR DESCRIPTION
When retrieving objects that have pointers to children, you can fetch child objects by using the include option.
