### PR TITLE
Fix 400 error on findMany

### DIFF
--- a/lib/Parse.js
+++ b/lib/Parse.js
@@ -41,7 +41,7 @@ Parse.prototype = {
     if (arguments.length === 3) {
       var callback = order;
       var order = undefined;
-      var limit = undefined;
+      var limit = 9999;
     }
 
     if (typeof(query) === 'string') {


### PR DESCRIPTION
It seems now parse does not allow the limit to be ''. So, making it 9999 should solve this?? I hate to make it a static number, maybe make it a larger number?
