### PR TITLE
Override `querystring.escape` only locally

### DIFF
--- a/lib/Parse.js
+++ b/lib/Parse.js
@@ -1,6 +1,5 @@
 var qs = require('querystring');
 
-qs.escape = function(q){ return q; };
 
 module.exports = Parse;
 
@@ -277,7 +276,13 @@ function parseRequest(method, path, data, callback, contentType) {
   switch (method) {
     case 'GET':
       if (data) {
+        // Avoid globally overriding `querystring.escape`:
+        // http://nodejs.org/api/querystring.html#querystring_querystring_escape
+        var originalEscape = qs.escape;
+        qs.escape = function(q){ return q; };
         path += (path.indexOf("?") == -1 ? '?' : '&') + qs.stringify(data);
+        qs.escape = originalEscape;
+
       }
       break;
     case 'POST':


### PR DESCRIPTION
First of all, thanks for all your great work on this Node.js Parse API client library.

This fixes a huge, but subtle bug that broke all query string encoding in our project (https://mix.fiftythree.com/). I am not blaming you specifically as you used the API as designed and documented and probably not realizing its side-effects.

In my opinion, Node’s global `querystring.escape` is just poor API design. Since Node modules are cached in memory, overwriting `querystring.escape` will overwrite it for every other client of that module which can lead to subtle, hard to find bugs. In my case, HTML emails using `querystring.stringify` to escape query string parameters started being truncated due to unescaped `&` once I added `node-parse-api` as a dependency.

Workaround: Overwrite `querystring.escape`, use `querystring.stringify`, and then restore `querystring.escape` to original implementation.

FYI, I filed a bug against Node.js core for this: https://github.com/joyent/node/issues/8672
