### PR TITLE
Modified Auth header from http basic auth to Parse REST API specs

### DIFF
--- a/lib/Parse.js
+++ b/lib/Parse.js
@@ -265,10 +265,10 @@ function reformatDatesFromParse(object){
 
 // Parse.com https api request
 function parseRequest(method, path, data, callback, contentType) {
-  var auth = 'Basic ' + new Buffer(this._application_id + ':' + this._master_key).toString('base64');
+  // auth utilizing REST API headers
   var headers = {
-    Authorization: auth,
-    Connection: 'Keep-alive'
+      "X-Parse-Application-Id" : this._application_id,
+      "X-Parse-REST-API-Key": this._master_key
   };
 
   var body = null;


### PR DESCRIPTION
changed http simple auth base64 to Parse REST API headers (X-Parse-Application-Id, X-Parse-REST-API-Key).  from https://www.parse.com/docs/rest