### PR TITLE
allow posting arbitrary data to /installations

### DIFF
--- a/lib/Parse.js
+++ b/lib/Parse.js
@@ -272,6 +272,12 @@ Parse.prototype = {
         parseRequest.call(this, 'GET', '/1/installations?where={"deviceToken":"'+deviceToken+'"}', null, callback);
     },
 
+    upsertInstallation: function(deviceType, deviceToken, data, callback) {
+        data.deviceType = deviceType;
+        data.deviceToken = deviceToken;
+        parseRequest.call(this, 'POST', '/1/installations', data, callback);
+    },
+
     insertOrUpdateInstallationDataWithChannels: function(deviceType, deviceToken, channels, callback) {
         var that = this;
         this.getInstallationDataForDeviceToken(deviceToken, function(err, results) {

--- a/lib/Parse.js
+++ b/lib/Parse.js
@@ -272,6 +272,10 @@ Parse.prototype = {
         parseRequest.call(this, 'GET', '/1/installations?where={"deviceToken":"'+deviceToken+'"}', null, callback);
     },
 
+    deleteInstallation: function(objectId, callback) {
+      parseRequest.call(this, 'DELETE', '/1/installations/' + objectId, null, callback);
+    },
+
     upsertInstallation: function(deviceType, deviceToken, data, callback) {
         data.deviceType = deviceType;
         data.deviceToken = deviceToken;

--- a/test/Parse.test.js
+++ b/test/Parse.test.js
@@ -235,6 +235,15 @@ exports.deleteAll = function (test) {
   });
 };
 
+exports.installationTests = {
+  upsertInstallation: function(test) {
+    parse.upsertInstallation('ios', '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef', {userID: 'jenny'}, function(error, response) {
+      test.ok(!error, 'There shouldn\'t be an error object');
+      test.done();
+    });
+  }
+}
+
 exports.userTests = {
   insertUser : function (test) {
     test.expect(1);

--- a/test/Parse.test.js
+++ b/test/Parse.test.js
@@ -241,6 +241,16 @@ exports.installationTests = {
       test.ok(!error, 'There shouldn\'t be an error object');
       test.done();
     });
+  },
+
+  deleteInstallation: function(test) {
+    parse.getInstallationDataForDeviceToken('0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef', function(error, response) {
+      var id = response.results[0].objectId;
+      parse.deleteInstallation(id, function(error, response){
+        test.ok(!error, 'There shouldn\'t be an error obejct');
+        test.done();
+      });
+    });
   }
 }
 


### PR DESCRIPTION
For my use case I am posting some arbitrary data along with the deviceToken on installations (mainly a userID, but perhaps other metadata about the user as well) and needed a method on the client to support that. Would you be interested in merging this in? Thanks for the helpful module!