### PR TITLE
Changed the parse options variable "host" field to "hostname"

### DIFF
--- a/lib/Parse.js
+++ b/lib/Parse.js
@@ -395,7 +395,7 @@ function parseRequest(method, path, data, callback, contentType, sessionToken) {
     }
 
     var options = {
-        host: this._api_host,
+        hostname: this._api_host,
         port: this._api_port,
         headers: headers,
         path: path,

--- a/lib/Parse.js
+++ b/lib/Parse.js
@@ -59,7 +59,7 @@ Parse.prototype = {
             // check to see if there is a 'where' object in the query object
             // the 'where' object need to be stringified by JSON.stringify(), not querystring
             if ( query.hasOwnProperty('where') ) {
-                url += '?where=' + JSON.stringify(query.where);
+               url += '?where=' + encodeURIComponent(JSON.stringify(query.where));
                 delete query.where;
             }
 

--- a/lib/Parse.js
+++ b/lib/Parse.js
@@ -34,6 +34,13 @@ Parse.prototype = {
         parseRequest.call(this, 'POST', '/1/users/', data, callback);
     },
 
+    findWithObjectId: function (className, objectId, callback){
+        var url = '/1/' + (className === '_User' ? 'users' : 'classes/' + className + '/' + objectId);
+
+
+        parseRequest.call(this, 'GET', url, null, callback);
+
+    },
     // get an object from the class store
     find: function (className, query, callback) {
         var url = '/1/' + (className === '_User' ? 'users' : 'classes/' + className);
@@ -52,7 +59,7 @@ Parse.prototype = {
             // check to see if there is a 'where' object in the query object
             // the 'where' object need to be stringified by JSON.stringify(), not querystring
             if ( query.hasOwnProperty('where') ) {
-                url += '?where=' + encodeURIComponent(JSON.stringify(query.where));
+                url += '?where=' + JSON.stringify(query.where);
                 delete query.where;
             }
 
@@ -95,6 +102,8 @@ Parse.prototype = {
     // user login
     loginUser: function (username, password, callback) {
         parseRequest.call(this, 'GET', '/1/login/?username=' + username + '&password=' + password, null, callback);
+
+        console.log(callback);
     },
 
     // retrieve current user
@@ -347,7 +356,13 @@ Parse.prototype = {
 
     sendPush: function (data, callback) {
         parseRequest.call(this, 'POST', '/1/push/', data, callback);
+    },
+    
+    getCurrentSession: function(objectId, callback)
+    {
+      parseRequest.call(this, 'GET', '/1/sessions/'+ objectId, callback);  
     }
+    
 };
 
 // Parse.com https api request

--- a/lib/Parse.js
+++ b/lib/Parse.js
@@ -102,8 +102,6 @@ Parse.prototype = {
     // user login
     loginUser: function (username, password, callback) {
         parseRequest.call(this, 'GET', '/1/login/?username=' + username + '&password=' + password, null, callback);
-
-        console.log(callback);
     },
 
     // retrieve current user


### PR DESCRIPTION
I read somewhere that this is better and it has personally prevented the "[Error: getaddrinfo ENOTFOUND api.parse.com]" error I get occasionally.