### PR TITLE
Bug Fixes: deleteUser, find

### DIFF
--- a/lib/Parse.js
+++ b/lib/Parse.js
@@ -206,6 +206,7 @@ Parse.prototype = {
     deleteUser: function (objectId, sessionToken, callback) {
         switch ( arguments.length ) {
             case 2: callback = sessionToken;
+                    sessionToken = null;
                     break;
             case 3: break;
             default: throw new Error('Unexpected number of arguments');

--- a/lib/Parse.js
+++ b/lib/Parse.js
@@ -45,6 +45,7 @@ Parse.prototype = {
     find: function (className, query, callback) {
         var url = '/1/' + (className === '_User' ? 'users' : 'classes/' + className);
         var queryType = typeof query;
+        var query = JSON.parse(JSON.stringify(query)); // deep clone object
         if ( queryType === 'string' ) {
             url += '/' + query;
         } else if ( queryType === 'object' ) {

--- a/test/Parse.test.js
+++ b/test/Parse.test.js
@@ -123,7 +123,24 @@ exports.findManyWithConstraints = {
       test.equal('qux1', response.results[1].baz, 'response.results[1].baz should be "qux1".');
       test.done();
     });
-  }
+  },
+  'leaves query object intact': function (test) {
+    var query = {
+      objectId: 'xyz',
+      where: {
+        foo: 'bar'
+      },
+      order: 'foo',
+      keys: 'baz',
+      skip: 2
+    };
+    var queryStr = JSON.stringify(query);
+    parse.find(className, query, function (error, response) {
+      queryStr2 = JSON.stringify(query);
+      test.equal(queryStr, queryStr2, 'query object should be intact');
+      test.done();
+    });
+  },
 };
 
 exports.deprecatedFindMany = {


### PR DESCRIPTION
The main thrust of this pull request is to fix a bug we have encountered where `find` deletes the `objectId` and `where` properties off of the original object passed into the `query` parameter. This is a problem in the case that you have multiple calls to find and delete objects using the same constraints. For example:

* a function `findAndDelete` finds object by className, query, then deletes by resulting objectId
* user wants to call `findAndDelete` multiple times, eg on:
  * `Article` with pointer to `User` as author
  * `Comment` with pointer to `User` author
  * `Image` with pointer to `User`
  * etc.

In this case, the first call finds the intended object via the query conditions, but deletes the `objectId` and `where` properties off of the query object that is passed into subsequent calls to `find`. Those subsequent calls to find thus return **all records in the table**, and they are deleted.

The PR also adds a test to cover the described bug, and fixes another bug causing the `deleteUser` test to fail when sessionToken is not passed in. All tests now passing.