### PR TITLE
Fix password reset endpoint URL

### DIFF
--- a/lib/Parse.js
+++ b/lib/Parse.js
@@ -194,7 +194,7 @@ Parse.prototype = {
     // reset a User object's password
     passwordReset: function (data, callback) {
         data = { email: data };
-        parseRequest.call(this, 'POST', '/1/requestPasswordReset/', data, callback);
+        parseRequest.call(this, 'POST', '/1/requestPasswordReset', data, callback);
     },
 
     // remove an object from the class store


### PR DESCRIPTION
POST /1/requestPasswordReset/ returns error "Requested resource was not found". Changed it to POST /1/requestPasswordReset/ which fixes it.