### PR TITLE
adds session token as constructor option

### DIFF
--- a/lib/Parse.js
+++ b/lib/Parse.js
@@ -360,12 +360,12 @@ Parse.prototype = {
     sendPush: function (data, callback) {
         parseRequest.call(this, 'POST', '/1/push/', data, callback);
     },
-    
+
     getCurrentSession: function(objectId, callback)
     {
-      parseRequest.call(this, 'GET', '/1/sessions/'+ objectId, callback);  
+      parseRequest.call(this, 'GET', '/1/sessions/'+ objectId, callback);
     }
-    
+
 };
 
 // Parse.com https api request
@@ -386,6 +386,10 @@ function parseRequest(method, path, data, callback, contentType, sessionToken) {
         if ( sessionToken ) {
             headers['X-Parse-Session-Token'] = sessionToken;
         }
+    }
+
+    if(!sessionToken && this._options && this._options.session_token){
+        headers['X-Parse-Session-Token'] = this._options.session_token;
     }
 
 
@@ -450,7 +454,7 @@ function parseRequest(method, path, data, callback, contentType, sessionToken) {
             callback(err);
         });
     });
-	
+
 	req.setTimeout(5000, function () {
 	    req.connection.destroy();
 	});

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-parse-api",
   "description": "A Parse.com REST API client for Node.js",
-  "version": "0.3.8",
+  "version": "0.3.8a",
   "author": "Chris Johnson <tenorviol@yahoo.com>, Michael Leveton <mleveton@prepcloud.com>, Seth Gholson",
   "contributors": [
     "Daniel Gasienica <daniel@gasienica.ch>",
@@ -20,7 +20,8 @@
     "Akhmad Fathonih",
     "Kody J. Peterson",
     "Jo Jordens",
-    "Appsaloon"
+    "Appsaloon",
+    "Achim Koellner"
   ],
   "main": "index",
   "scripts": {

--- a/readme.md
+++ b/readme.md
@@ -515,6 +515,33 @@ app.sendPush(notification, function(err, resp){
 });
 ```
 
+### usage of a sessionToken for all operations
+
+If you use node-parse-api with a logged-in user in a node.js server environement a client might send a sessionToken with a request against the server. 
+You can pass the client sessionToken from the client to performs database operations on behalf of that user session.
+
+This allows e.g. to find objects of classes that are restricted to be read by only that user (or role).
+
+```javascript
+var Parse = require('node-parse-api').Parse;
+
+// let's assume this is a sessionToken of an user who is member of the role "moderator"
+var sessionToken = '3h3gaa32bdd3h3gaa323h3gaa32bddbdd';
+
+var options = {
+    app_id:'...',
+    api_key:'...',
+    session_token: sessionToken // , master_key:'...' could be used too 
+}
+
+var app = new Parse(options);
+
+// let's assume Foo is a class with read permission for "moderator"-users only
+app.find('Foo', {objectId: 'someId'}, function (err, response) {
+    console.log(response);
+});
+```
+
 ### note on sending dates
 
 ```javascript

--- a/readme.md
+++ b/readme.md
@@ -517,15 +517,15 @@ app.sendPush(notification, function(err, resp){
 
 ### usage of a sessionToken for all operations
 
-If you use node-parse-api with a logged-in user in a node.js server environement a client might send a sessionToken with a request against the server. 
-You can pass the client sessionToken from the client to performs database operations on behalf of that user session.
+If you use node-parse-api in a node.js server environement a client might send a sessionToken with a request to your server. 
+You can pass that sessionToken as a constructor option to perform database operations on behalf of that user session.
 
 This allows e.g. to find objects of classes that are restricted to be read by only that user (or role).
 
 ```javascript
 var Parse = require('node-parse-api').Parse;
 
-// let's assume this is a sessionToken of an user who is member of the role "moderator"
+// let's assume this is a sessionToken of a user who is member of the role "moderator"
 var sessionToken = '3h3gaa32bdd3h3gaa323h3gaa32bddbdd';
 
 var options = {

--- a/readme.md
+++ b/readme.md
@@ -191,7 +191,7 @@ app.find('Foo', query, function (error, response ) {
 * getUser(query `object`, callback `function`)
 
 ```javascript
-app.find({objectId: 'someId'}, function (err, response) {
+app.getUser({objectId: 'someId'}, function (err, response) {
   console.log(response);
 });
 ```


### PR DESCRIPTION
I'd love to use node-parse-api with a logged-in user. The node server receives a sessionToken from the client and performs database operations on behalf of that session.
For that purpose the session_token (besides app_key and api_key) can be passed to the constructor.

If no sessionToken is passed to the parseRequest method by argument, the method checks if the constructor options contain a session_token value and sends an X-Parse-Session-Token header with the request.

This allows e.g. to find objects of classes that are restricted to be read by only that user (or role).

    
    // example usage
    var Parse = require('node-parse-api').Parse;

    // let's assume this is a sessionToken of an user who is member of the role "moderator"
    var sessionToken = '3h3gaa32bdd3h3gaa323h3gaa32bddbdd';
 
    var options = {
        app_id:'...',
        api_key:'...',
        session_token: sessionToken // , master_key:'...' could be used too 
    }
     
    var app = new Parse(options);

    // let's assume Foo is a class with read permission for "moderator"-users only
    app.find('Foo', {objectId: 'someId'}, function (err, response) {
        console.log(response);
    });
