### PR TITLE
Don't override global querystring.escape

### DIFF
--- a/lib/Parse.js
+++ b/lib/Parse.js
@@ -62,10 +62,7 @@ Parse.prototype = {
             }
 
             // if there are no more constraints left in the query object 'remainingQuery' will be an empty string
-            var oldEscape = qs.escape;
-            qs.escape = function(q){ return q; };
-            var remainingQuery = qs.stringify(query);
-            qs.escape = oldEscape;
+            var remainingQuery = qsStringify(query);
             if ( remainingQuery ) {
                 url += ( url.indexOf('?') === -1 ? '?' : '&' ) + remainingQuery;
             }
@@ -395,10 +392,7 @@ function parseRequest(method, path, data, callback, contentType, sessionToken) {
     switch (method) {
         case 'GET':
             if (data) {
-                var oldEscape = qs.escape;
-                qs.escape = function(q){ return q; };
-                path += (path.indexOf("?") == -1 ? '?' : '&') + qs.stringify(data);
-                qs.escape = oldEscape;
+                path += (path.indexOf("?") == -1 ? '?' : '&') + qsStringify(data);
             }
             break;
         case 'POST':
@@ -474,4 +468,12 @@ function toDeleteOps(className, objects){
             path: '/1/' + ( className === '_User' ? 'users/' : 'classes/' + className + '/' ) + object.objectId
         };
     });
+}
+
+function qsStringify(str) {
+    var oldEscape = qs.escape;
+    qs.escape = function(q){ return q; };
+    var stringified = qs.stringify(str);
+    qs.escape = oldEscape;
+    return stringified;
 }

--- a/lib/Parse.js
+++ b/lib/Parse.js
@@ -1,7 +1,5 @@
 var qs = require('querystring');
 
-qs.escape = function(q){ return q; };
-
 module.exports = Parse;
 
 function Parse(options_or_application_id, master_key) {
@@ -64,7 +62,10 @@ Parse.prototype = {
             }
 
             // if there are no more constraints left in the query object 'remainingQuery' will be an empty string
+            var oldEscape = qs.escape;
+            qs.escape = function(q){ return q; };
             var remainingQuery = qs.stringify(query);
+            qs.escape = oldEscape;
             if ( remainingQuery ) {
                 url += ( url.indexOf('?') === -1 ? '?' : '&' ) + remainingQuery;
             }
@@ -394,7 +395,10 @@ function parseRequest(method, path, data, callback, contentType, sessionToken) {
     switch (method) {
         case 'GET':
             if (data) {
+                var oldEscape = qs.escape;
+                qs.escape = function(q){ return q; };
                 path += (path.indexOf("?") == -1 ? '?' : '&') + qs.stringify(data);
+                qs.escape = oldEscape;
             }
             break;
         case 'POST':


### PR DESCRIPTION
Bringing back @gasi's change (#16). Not sure why it was reverted at some point, but we were also running into some issues with the global querystring.escape override.